### PR TITLE
New Dockerfile that uses an Ubuntu image

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Activate it with
 `source venv/bin/activate`
 
 Add a file to `venv/lib/python3.9/site-packages/benchmarking.pth` with the contents: 
-`/PATH/TO/REPO/Auto-GPT-Benchmarks-fork`
+`/PATH/TO/REPO/Auto-GPT-Benchmarks
 
 This is because evals tries to import it directly.
 
@@ -56,7 +56,7 @@ Install the requirements with
 You must have a docker container built corresponding to the submodule below or the docker run command starting the agent will fail.
 
 Cd into the AutoGPT submodule and build/tag the dockerfile so the agent can be instantiated.
-`cd auto_gpt_benchmarks/Auto-GPT`
+`cd auto_gpt_benchmarking/Auto-GPT`
 
 Build the container so we can run it procedurally!
 `docker build -t autogpt .`


### PR DESCRIPTION
This Dockerfile can be a drop-in replacement for the AutoGPT submodule of this repo. I was able to build and run the the Ubuntu container using the commands in this repo's `README.` 

The only new installs that I added were:

`python3.10`
`python3-pip`

as they no longer come in the base image we are building from.

Pwuts mentioned in the Discord today that the AutoGPT repo is moving to `python3.10` because of a compatability issue with `sourcery` and `python3.11`. 

I also had to create a script so that `python=python3.10` in both interactive and non-interactive bash shells. But for most users they'll never be typing that as the entry point has remained the same, `python -m autogpt`

I also changed the commands that add the signing keys for `chromium` and `firefox-esr` because Ubuntu was complaining about `apt-key` and `add-apt-repository` being deprecated soon.
 
I also made some small changes to the `README` of Auto-GPT-Benchmarks to clarify the file paths people need to use during setup.