### PR TITLE
Print out all of stdout on each process poll.

### DIFF
--- a/agbenchmark/agent_interface.py
+++ b/agbenchmark/agent_interface.py
@@ -61,8 +61,9 @@ def run_agent(
         while True:
             if process.stdout is None:
                 continue
-            output = process.stdout.readline()
-            print(output.strip())
+
+            while output := process.stdout.readline():
+                print(output.strip())
 
             # Check if process has ended
             if process.poll() is not None:


### PR DESCRIPTION
Before this change stdout would only be printed one line per poll, which means that we may not have read all output by the time the process exited.