### PR TITLE
Remove dependencies cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,14 +38,6 @@ jobs:
         run: |
           curl -sSL https://install.python-poetry.org | python -
 
-      - name: Set up Poetry cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cache/pypoetry
-            .venv
-          key: ${{ runner.os }}-poetry-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/poetry.lock') }}-${{ steps.get_date.outputs.date }}
-
       - name: Install dependencies
         run: |
           poetry install
@@ -106,14 +98,6 @@ jobs:
       - name: Install Poetry
         run: |
           curl -sSL https://install.python-poetry.org | python -
-
-      - name: Set up Poetry cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cache/pypoetry
-            .venv
-          key: ${{ runner.os }}-poetry-${{ hashFiles('**/pyproject.toml') }}-${{ hashFiles('**/poetry.lock') }}-${{ steps.get_date.outputs.date }}
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
### Background
<!-- Provide a concise overview of the rationale behind this change. Include relevant context, prior discussions, or links to related issues. Ensure that the change aligns with the project's overall direction. -->
It turns out the cache would save agbenchmark's state of the first CI run of the day. And this morning there was a bug that duplicated agent calls.
So to avoid issues, I disable caching, we only gain a few seconds from it.
### Changes
<!-- Describe the specific, focused change made in this pull request. Detail the modifications clearly and avoid any unrelated or "extra" changes. -->


### PR Quality Checklist
- [X] I have run the following commands against my code to ensure it passes our linters:
    ```shell
    black .
    isort .
    mypy .
    autoflake --remove-all-unused-imports --recursive --ignore-init-module-imports --ignore-pass-after-docstring --in-place agbenchmark
    ```
