### PR TITLE
Setup subprocess in a thread so timeout works without output

### DIFF
--- a/agbenchmark/challenges/test_all.py
+++ b/agbenchmark/challenges/test_all.py
@@ -54,7 +54,7 @@ def generate_tests() -> None:
 
         # Define test method within the dynamically created class
         def test_method(self, config: Dict[str, Any]) -> None:  # type: ignore
-            cutoff = self.data.cutoff or 60
+            cutoff = self.data.cutoff or int(config.get("cutoff", 60))
             self.setup_challenge(config, cutoff)
 
             scores = self.get_scores(config)


### PR DESCRIPTION
### Background
When a challenge is running but hangs without producing output, the timeout won't kick in because `process.stdout.readline()` doesn't return unless there's output. This happens in the `TestCreateSimpleWebServer` test specifically.

### Changes
Change the stdout of the subprocess to use the main process's stdout. This means we don't have to check output and print it. This does mean that if we want to capture stdout of the process in some other way we'll have to make another change.

I did some refactoring to make it easier to do further changes if we desire.


### PR Quality Checklist
- [x] I have run the following commands against my code to ensure it passes our linters:
    ```shell
    black .
    isort .
    mypy .
    autoflake --remove-all-unused-imports --recursive --ignore-init-module-imports --ignore-pass-after-docstring --in-place agbenchmark
    ```
