### PR TITLE
added new script to fix dynamic headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
     branches: [master]
   schedule:
-    - cron: '0 8 * * *'
+    - cron: "0 8 * * *"
   push:
     branches: [master, ci-test*]
     paths-ignore:
-      - 'reports/**'
+      - "reports/**"
   pull_request:
     branches: [stable, master, release-*]
 
@@ -16,7 +16,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     env:
-      min-python-version: '3.10'
+      min-python-version: "3.10"
 
     steps:
       - name: Checkout repository
@@ -69,20 +69,20 @@ jobs:
   tests:
     env:
       GH_TOKEN: ${{ github.event_name == 'pull_request' && github.token || secrets.PAT }}
-      min-python-version: '3.10'
-    name: '${{ matrix.agent-name }}'
+      min-python-version: "3.10"
+    name: "${{ matrix.agent-name }}"
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         agent-name:
-          - 'gpt-engineer'
-          - 'smol-developer'
-          - 'Auto-GPT'
-          - 'mini-agi'
-          - 'beebot'
-          - 'BabyAGI'
+          - "gpt-engineer"
+          - "smol-developer"
+          - "Auto-GPT"
+          - "mini-agi"
+          - "beebot"
+          - "BabyAGI"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -198,7 +198,7 @@ jobs:
             ${prefix}agbenchmark start --mock --suite TestReturnCode 
             ${prefix}agbenchmark start --mock --suite TestRevenueRetrieval
           else
-            bash -c "$(curl -fsSL https://raw.githubusercontent.com/merwanehamadi/helicone/003d3c829afc4de8595614f1241d1dfbf389d00a/mitmproxy.sh)" -s start
+            bash -c "$(curl -fsSL https://raw.githubusercontent.com/merwanehamadi/helicone/b7ab4bc53e51d8ab29fff19ce5986ab7720970c6/mitmproxy.sh)" -s start
             ${prefix}agbenchmark start --test=TestWriteFile || echo "This command will always return a non zero exit code unless all the challenges are solved."
           fi
 


### PR DESCRIPTION
This PR fixes dynamic headers not working in CI. The issue stemmed from lockfile not being installed, and my testing environment not matching github actions. It is actually really annoying that Github doensnt open up their containers that they use. 😢

Here is the PR for the main script changes: https://github.com/Helicone/helicone/pull/645/files

You can now run dynamic headers for all tests using the following commands.

```bash
python3 -m pip install helicone
```

```python
from helicone.lock import HeliconeLockManager
HeliconeLockManager.write_custom_property("job_id", "1")
'''
Other Methods:
 - write_custom_property(property_name: str, value: str) // Write a custom property
 - remove_custom_property(property_name: str) // remove a custom property
 - clear_all_properties() // clear all
'''
```