### PR TITLE
Remove baserun because api key issue

### DIFF
--- a/agbenchmark/start_benchmark.py
+++ b/agbenchmark/start_benchmark.py
@@ -214,8 +214,7 @@ def start(
 
     # when used as a library, the pytest directory to execute is in the CURRENT_DIRECTORY
     pytest_args.append(str(CURRENT_DIRECTORY))
-    if os.environ.get("BASERUN_API_KEY"):
-        pytest_args.extend(["--baserun"])
+
     return sys.exit(pytest.main(pytest_args))
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -259,20 +259,6 @@ files = [
 ]
 
 [[package]]
-name = "baserun"
-version = "0.3"
-description = "Tools for testing, debugging, and evaluating LLM features."
-optional = false
-python-versions = ">=3.7.1"
-files = [
-    {file = "baserun-0.3-py3-none-any.whl", hash = "sha256:b4570d3d3ab64b2fc346d1bd41aad145404e3d521065778dfd942e84056a302a"},
-    {file = "baserun-0.3.tar.gz", hash = "sha256:e7b8a63d1039228973c4a93c4a3b3df31f4b979a5d7476df12c7dd55c9bed41f"},
-]
-
-[package.dependencies]
-requests = ">=2.31.0"
-
-[[package]]
 name = "black"
 version = "22.3.0"
 description = "The uncompromising code formatter."
@@ -2730,4 +2716,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "d3f4df7a26eacfe0b726142521f20f3c98ee721b4710502e1ed7bffda3c9dff0"
+content-hash = "855fe892a4401b03bbda926df20c140ea5143574ff5d04b6168472a2d162b9dd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agbenchmark"
-version = "0.0.4"
+version = "0.0.5"
 description = "Benchmarking the performance of agents far and wide, regardless of how they are set up and how they work"
 authors = ["Silen Naihin <silen.naihin@gmail.com>"]
 license = "MIT"
@@ -27,7 +27,6 @@ colorama = "^0.4.6"
 pyvis = "^0.3.2"
 selenium = "^4.11.2"
 agent-protocol = "^0.2.3"
-baserun = "^0.3"
 
 [tool.poetry.group.dev.dependencies]
 flake8 = "^3.9.2"


### PR DESCRIPTION
### Background

<!-- IF YOU MAKE A PR FROM A FORK, THE mini-agi TEST WON'T PASS, so ignore it.-->

### Changes

<!-- Describe the specific, focused change made in this pull request. Detail the modifications clearly and avoid any unrelated or "extra" changes. -->

### PR Quality Checklist

- [X] I have run the following commands against my code to ensure it passes our linters:
  ```shell
  black . --exclude test.py
  isort .
  mypy .
  autoflake --remove-all-unused-imports --recursive --ignore-init-module-imports --ignore-pass-after-docstring --in-place agbenchmark
  ```
