### PR TITLE
Sync skill tree to a versioned website

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,12 +278,12 @@ jobs:
               if git push origin HEAD; then
                   echo "Success!"
                   poetry run python send_to_googledrive.py || echo "Failed to upload to Google Drive"
-                  echo "Adding skill-tree submodule to update website"
+                  echo "Adding skill_tree submodule to update website"
                   poetry run agbenchmark start --mock
-                  cd agbenchmark/challenges/skill-tree                  
+                  cd agbenchmark/challenges/skill_tree                  
                   git add .
                   git commit -m "Update website with new skill tree"
-                  git remote set-url origin https://x-access-token:${{ env.GH_TOKEN }}@github.com/merwanehamadi/merwanehamadi.github.io.git
+                  git remote set-url origin https://x-access-token:${{ env.GH_TOKEN }}@github.com/agbenchmark/skill-tree.github.io.git
                   git push origin HEAD:refs/heads/main
                   cd ../../..
                   exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,11 @@ jobs:
 
       - name: Setup Chrome and ChromeDriver
         run: |
+          echo "Add submodules"
+          cd agbenchmark/challenges
+          git submodule update --init --remote --recursive
+          cd ../..
+          
           sudo apt-get update
           sudo apt-get install -y unzip xvfb
           wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
@@ -273,6 +278,14 @@ jobs:
               if git push origin HEAD; then
                   echo "Success!"
                   poetry run python send_to_googledrive.py || echo "Failed to upload to Google Drive"
+                  echo "Adding skill-tree submodule to update website"
+                  poetry run agbenchmark start --mock
+                  cd agbenchmark/challenges/skill-tree                  
+                  git add .
+                  git commit -m "Update website with new skill tree"
+                  git remote set-url origin https://x-access-token:${{ env.GH_TOKEN }}@github.com/merwanehamadi/merwanehamadi.github.io.git
+                  git push origin HEAD:refs/heads/main
+                  cd ../../..
                   exit 0
               else
                   echo "Attempt $(($attempts + 1)) failed. Retrying..."
@@ -284,6 +297,8 @@ jobs:
         env:
           GDRIVE_BASE64: ${{ secrets.GDRIVE_BASE64 }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
+          BUILD_SKILL_TREE: true
+          AGENT_NAME: ${{ matrix.agent-name }}
 
   generate_charts:
     needs: tests

--- a/.gitmodules
+++ b/.gitmodules
@@ -33,3 +33,7 @@
 [submodule "agbenchmark/challenges"]
 	path = agbenchmark/challenges
 	url = https://github.com/agbenchmark/agent-evals.git
+[submodule "skill-tree"]
+	path = skill-tree
+	url = https://github.com/agbenchmark/skill-tree.github.io
+	branch = main

--- a/agbenchmark/utils/dependencies/graphs.py
+++ b/agbenchmark/utils/dependencies/graphs.py
@@ -266,7 +266,7 @@ def graph_interactive_network(
         "layout": {"hierarchical": hierarchical_options},
     }
 
-    relative_path = "agbenchmark/challenges/dependencies.html"
+    relative_path = "agbenchmark/challenges/skill-tree/dependencies.html"
     file_path = str(Path(relative_path).resolve())
 
     if show:
@@ -279,7 +279,7 @@ def graph_interactive_network(
     ]
 
     iframe_path = "dependencies.html"
-    combined_file_path = "agbenchmark/challenges/combined_view.html"
+    combined_file_path = "agbenchmark/challenges/skill-tree/combined_view.html"
 
     create_combined_html(combined_file_path, iframe_path, table_data)
     # JavaScript code snippet to be inserted
@@ -295,7 +295,7 @@ def graph_interactive_network(
     """
 
     # Path to the iframe HTML file
-    iframe_path = "agbenchmark/challenges/dependencies.html"
+    iframe_path = "agbenchmark/challenges/skill-tree/dependencies.html"
 
     # Insert the JS code snippet into the iframe HTML file
     insert_js_into_iframe(iframe_path, iframe_js_code)

--- a/agbenchmark/utils/dependencies/graphs.py
+++ b/agbenchmark/utils/dependencies/graphs.py
@@ -266,7 +266,7 @@ def graph_interactive_network(
         "layout": {"hierarchical": hierarchical_options},
     }
 
-    relative_path = "agbenchmark/challenges/skill-tree/dependencies.html"
+    relative_path = "agbenchmark/challenges/skill_tree/dependencies.html"
     file_path = str(Path(relative_path).resolve())
 
     if show:
@@ -279,7 +279,7 @@ def graph_interactive_network(
     ]
 
     iframe_path = "dependencies.html"
-    combined_file_path = "agbenchmark/challenges/skill-tree/combined_view.html"
+    combined_file_path = "agbenchmark/challenges/skill_tree/combined_view.html"
 
     create_combined_html(combined_file_path, iframe_path, table_data)
     # JavaScript code snippet to be inserted
@@ -295,7 +295,7 @@ def graph_interactive_network(
     """
 
     # Path to the iframe HTML file
-    iframe_path = "agbenchmark/challenges/skill-tree/dependencies.html"
+    iframe_path = "agbenchmark/challenges/skill_tree/dependencies.html"
 
     # Insert the JS code snippet into the iframe HTML file
     insert_js_into_iframe(iframe_path, iframe_js_code)

--- a/agbenchmark/utils/dependencies/main.py
+++ b/agbenchmark/utils/dependencies/main.py
@@ -7,6 +7,7 @@ __init__.py.
 
 import collections
 import json
+import os
 from typing import Any, Generator, Optional
 
 import colorama
@@ -195,6 +196,12 @@ class DependencyManager(object):
     def sorted_items(self, show_graph: Optional[bool] = False) -> Generator:
         """Get a sorted list of tests where all tests are sorted after their dependencies."""
         # Build a directed graph for sorting
+        build_skill_tree = os.getenv("BUILD_SKILL_TREE")
+        BUILD_SKILL_TREE = (
+            build_skill_tree.lower() == "true" if build_skill_tree else False
+        )
+        if BUILD_SKILL_TREE:
+            show_graph = True
         dag = networkx.DiGraph()
 
         # Insert all items as nodes, to prevent items that have no dependencies and are not dependencies themselves from


### PR DESCRIPTION
### Background

<!-- IF YOU MAKE A PR FROM A FORK, THE mini-agi TEST WON'T PASS, so ignore it.-->

### Changes

<!-- Describe the specific, focused change made in this pull request. Detail the modifications clearly and avoid any unrelated or "extra" changes. -->
- github.io is pretty useful to have versioned websites linked to each release => quick prototype.
- I need the next release of agbenchmark to release the skill tree, so we can get feedback from users.

### PR Quality Checklist

- [X] I have run the following commands against my code to ensure it passes our linters:
  ```shell
  black . --exclude test.py
  isort .
  mypy .
  autoflake --remove-all-unused-imports --recursive --ignore-init-module-imports --ignore-pass-after-docstring --in-place agbenchmark
  ```
